### PR TITLE
fix: RDCC-2413 replaced location ref load key vaults for storage account

### DIFF
--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -1,14 +1,15 @@
 spring:
   cloud:
     propertiesvolume:
-      prefixed: true
+      prefixed: false
       paths: /mnt/secrets/rd
       aliases:
-        rd.location-ref-api-POSTGRES-PASS: spring.datasource.password
-        rd.AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
-        rd.rd-location-storage-account-name: ACCOUNT_NAME
-        rd.rd-location-storage-account-primary-key: ACCOUNT_KEY
-        rd.CONTAINER-NAME: CONTAINER_NAME
-        rd.BLOB-URL-SUFFIX: BLOB_URL_SUFFIX
+        location-ref-api-POSTGRES-PASS: spring.datasource.password
+        AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
+        rd-location-storage-account-name: ACCOUNT_NAME
+        rd-location-storage-account-primary-key: ACCOUNT_KEY
+        CONTAINER-NAME: CONTAINER_NAME
+        BLOB-URL-SUFFIX: BLOB_URL_SUFFIX
+
 
 

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -10,6 +10,3 @@ spring:
         rd-location-storage-account-primary-key: ACCOUNT_KEY
         CONTAINER-NAME: CONTAINER_NAME
         BLOB-URL-SUFFIX: BLOB_URL_SUFFIX
-
-
-


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-2413


### Change description ###
fix: RDCC-2413 replaced location ref load key vaults for storage account


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
