### PR TITLE
fix: Stale files with truncate sql not roll-backing to existing data(RDCC-2251)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,7 +249,7 @@ dependencies {
       'it is possible that information could leak between requests'
   }
 
-  compile group: 'uk.gov.hmcts.reform', name: 'data-ingestion-lib', version: '0.4.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'data-ingestion-lib', version: '0.4.2.1.beta'
   compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/build.gradle
+++ b/build.gradle
@@ -236,20 +236,8 @@ dependencies {
   compile group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
 
   compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
-  implementation('org.apache.tomcat.embed:tomcat-embed-core:9.0.40') {
-    because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
-      'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
-      'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
-      'it is possible that information could leak between requests'
-  }
-  implementation('org.apache.tomcat.embed:tomcat-embed-websocket:9.0.40') {
-    because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
-      'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
-      'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
-      'it is possible that information could leak between requests'
-  }
 
-  compile group: 'uk.gov.hmcts.reform', name: 'data-ingestion-lib', version: '0.4.2.1.beta'
+  compile group: 'uk.gov.hmcts.reform', name: 'data-ingestion-lib', version: '0.4.2.2'
   compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdApplicationExceptionAndAuditTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdApplicationExceptionAndAuditTest.java
@@ -61,7 +61,7 @@ public class LrdApplicationExceptionAndAuditTest extends LrdIntegrationBaseTest 
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
     public void testTaskletPartialSuccessAndJsr() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-partial-success.csv"))
         );
@@ -75,18 +75,18 @@ public class LrdApplicationExceptionAndAuditTest extends LrdIntegrationBaseTest 
                 .ccdServiceName("ccd-service1").serviceCode("AAA1").build()
         ), 2);
         //Validates Success Audit
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "PartialSuccess","service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "PartialSuccess", UPLOAD_FILE_NAME);
         Triplet<String, String, String> triplet = with("serviceCode", "must not be blank", "");
         validateLrdServiceFileJsrException(jdbcTemplate, exceptionQuery, 1, triplet);
         //Delete Uploaded test file with Snapshot delete
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 
     @Test
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
     public void testTaskletFailure() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-failure.csv"))
         );
@@ -96,17 +96,17 @@ public class LrdApplicationExceptionAndAuditTest extends LrdIntegrationBaseTest 
         assertEquals(serviceToCcdServices.size(), 0);
 
         Pair<String, String> pair = new Pair<>(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             "ServiceToCcdService failed as no valid records present"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Failure", "service-test.csv");
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Failure", UPLOAD_FILE_NAME);
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 
     private void testInsertion() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test.csv"))
         );
@@ -124,16 +124,16 @@ public class LrdApplicationExceptionAndAuditTest extends LrdIntegrationBaseTest 
                 .ccdServiceName("ccd-service2").serviceCode("AAA2").build()
         ), 4);
         //Validates Success Audit
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", "service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", UPLOAD_FILE_NAME);
         //Delete Uploaded test file with Snapshot delete
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 
     @Test
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
     public void testTaskletFailureForInvalidService() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-invalid-service-failure.csv"))
         );
@@ -143,11 +143,11 @@ public class LrdApplicationExceptionAndAuditTest extends LrdIntegrationBaseTest 
         assertEquals(serviceToCcdServices.size(), 0);
 
         Pair<String, String> pair = new Pair<>(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             "violates foreign key constraint"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Failure", "service-test.csv");
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Failure", UPLOAD_FILE_NAME);
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdApplicationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdApplicationTest.java
@@ -94,7 +94,7 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
         platformTransactionManager.commit(status);
         SpringRestarter.getInstance().restart();
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-day2.csv"))
         );
@@ -113,13 +113,13 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
             ServiceToCcdCaseType.builder().ccdCaseType("service16")
                 .ccdServiceName("ccd-service2").serviceCode("AAA2").build()
         ), 4);
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", "service-test.csv");
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", UPLOAD_FILE_NAME);
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 
     private void testInsertion() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test.csv"))
         );
@@ -137,16 +137,16 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
                 .ccdServiceName("ccd-service2").serviceCode("AAA2").build()
         ), 4);
         //Validates Success Audit
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", "service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", UPLOAD_FILE_NAME);
         //Delete Uploaded test file with Snapshot delete
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 
     @Test
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
     public void testTaskletIdempotent() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test.csv"))
         );
@@ -157,7 +157,7 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
         SpringRestarter.getInstance().restart();
 
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-empty-case-or-name.csv"))
         );
@@ -176,12 +176,12 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
                 .ccdServiceName("ccd-service2").serviceCode("AAA2").build()
         ), 4);
         //Validates Success Audit
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", "service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", UPLOAD_FILE_NAME);
         //Delete Uploaded test file with Snapshot delete
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
         dataIngestionLibraryRunner.run(jobLauncherTestUtils.getJob(),params);
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-empty-case-or-name.csv"))
         );
@@ -189,14 +189,14 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
         List<Map<String, Object>> auditDetailsNextRun = jdbcTemplate.queryForList(auditSchedulerQuery);
         final Timestamp timestampNextRun = (Timestamp) auditDetailsNextRun.get(0).get("scheduler_end_time");
         assertEquals(timestamp,timestampNextRun);
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 
     @Test
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
     public void testTaskletSuccessWithEmptyCaseTypeOrName() throws Exception {
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test-empty-case-or-name.csv"))
         );
@@ -220,8 +220,8 @@ public class LrdApplicationTest extends LrdIntegrationBaseTest {
                 .ccdCaseType(EMPTY).build()
         ), 6);
         //Validates Success Audit
-        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", "service-test.csv");
+        validateLrdServiceFileAudit(jdbcTemplate, auditSchedulerQuery, "Success", UPLOAD_FILE_NAME);
         //Delete Uploaded test file with Snapshot delete
-        lrdBlobSupport.deleteBlob("service-test.csv");
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdFileStatusCheckTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdFileStatusCheckTest.java
@@ -91,7 +91,7 @@ public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
             .toJobParameters();
         jobLauncherTestUtils.launchJob(params);
         Pair<String, String> pair = new Pair<>(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             "not loaded due to file stale error"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
@@ -104,7 +104,7 @@ public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
     }
 
     private void deleteFile() throws Exception {
-        lrdBlobSupport.deleteBlob("service-test.csv", false);
+        lrdBlobSupport.deleteBlob(UPLOAD_FILE_NAME, false);
     }
 
     @Test
@@ -130,7 +130,7 @@ public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
             .toJobParameters();
         jobLauncherTestUtils.launchJob(params);
         Pair<String, String> pair = new Pair<>(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             "service-test.csv file is not exists in container"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
@@ -151,7 +151,7 @@ public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
     private void uploadFiles(String time) throws Exception {
         camelContext.getGlobalOptions().put(SCHEDULER_START_TIME, time);
         lrdBlobSupport.uploadFile(
-            "service-test.csv",
+            UPLOAD_FILE_NAME,
             new FileInputStream(getFile(
                 "classpath:sourceFiles/service-test.csv"))
         );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdFileStatusCheckTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdFileStatusCheckTest.java
@@ -5,8 +5,12 @@ import org.apache.camel.test.spring.MockEndpoints;
 import org.javatuples.Pair;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
@@ -26,8 +30,12 @@ import uk.gov.hmcts.reform.locationrefdata.configuration.BatchConfig;
 
 import java.io.FileInputStream;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.util.ResourceUtils.getFile;
 import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.SCHEDULER_START_TIME;
 
@@ -45,6 +53,15 @@ import static uk.gov.hmcts.reform.data.ingestion.camel.util.MappingConstants.SCH
     transactionMode = SqlConfig.TransactionMode.ISOLATED)
 public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
 
+    @Value("${truncate-audit}")
+    protected String truncateAudit;
+
+    @Value("${truncate-exception}")
+    protected String truncateException;
+
+    @Value("${select-dataload-scheduler-failure}")
+    String lrdAuditSqlFailure;
+
     @Before
     public void init() {
         SpringRestarter.getInstance().restart();
@@ -52,42 +69,91 @@ public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
 
     @Test
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
-    public void testTaskletStaleFileError() throws Exception {
+    public void testTaskletStaleFileErrorDay2WithKeepingDay1Data() throws Exception {
 
-        camelContext.getGlobalOptions()
-            .put(SCHEDULER_START_TIME, String.valueOf(
-                new Date(System.currentTimeMillis() - 24 * 60 * 60 * 1000).getTime()));
+        //Day 1 happy path
+        uploadFiles(String.valueOf(new Date(System.currentTimeMillis()).getTime()));
 
-        lrdBlobSupport.uploadFile(
-            "service-test.csv",
-            new FileInputStream(getFile(
-                "classpath:sourceFiles/service-test.csv"))
-        );
+        JobParameters params = new JobParametersBuilder()
+            .addString(jobLauncherTestUtils.getJob().getName(), UUID.randomUUID().toString())
+            .toJobParameters();
+        dataIngestionLibraryRunner.run(jobLauncherTestUtils.getJob(), params);
+        deleteFile();
+        deleteAuditAndExceptionDataOfDay1();
 
-        jobLauncherTestUtils.launchJob();
+        //Day 2 stale files
+        uploadFiles(String.valueOf(new Date(System.currentTimeMillis() - 24 * 60 * 60 * 1000).getTime()));
+
+        //not ran with dataIngestionLibraryRunner to set stale file via camelContext.getGlobalOptions()
+        //.remove(SCHEDULER_START_TIME);
+        params = new JobParametersBuilder()
+            .addString(jobLauncherTestUtils.getJob().getName(), UUID.randomUUID().toString())
+            .toJobParameters();
+        jobLauncherTestUtils.launchJob(params);
         Pair<String, String> pair = new Pair<>(
             "service-test.csv",
             "not loaded due to file stale error"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
         var result = jdbcTemplate.queryForList(auditSchedulerQuery);
-        assertEquals(0, result.size());
+        assertEquals(1, result.size());
+        Assertions.assertEquals(1, jdbcTemplate.queryForList(lrdAuditSqlFailure).size());
+        List<Map<String, Object>> judicialUserRoleType = jdbcTemplate.queryForList(lrdSelectData);
+        assertFalse(judicialUserRoleType.isEmpty());
+        deleteFile();
+    }
+
+    private void deleteFile() throws Exception {
         lrdBlobSupport.deleteBlob("service-test.csv", false);
     }
 
     @Test
     @Sql(scripts = {"/testData/truncate-lrd.sql"})
-    public void testTaskletNoFileError() throws Exception {
-        camelContext.getGlobalOptions()
-            .put(SCHEDULER_START_TIME, String.valueOf(new Date(System.currentTimeMillis()).getTime()));
+    public void testTaskletNoFileErrorDay2WithKeepingDay1Data() throws Exception {
+        //Day 1 happy path
+        uploadFiles(String.valueOf(new Date(System.currentTimeMillis()).getTime()));
 
-        jobLauncherTestUtils.launchJob();
+        JobParameters params = new JobParametersBuilder()
+            .addString(jobLauncherTestUtils.getJob().getName(), UUID.randomUUID().toString())
+            .toJobParameters();
+        dataIngestionLibraryRunner.run(jobLauncherTestUtils.getJob(), params);
+        deleteFile();
+        deleteAuditAndExceptionDataOfDay1();
+
+        //Day 2 no upload file
+        camelContext.getGlobalOptions().put(
+            SCHEDULER_START_TIME,
+            String.valueOf(new Date(System.currentTimeMillis()).getTime())
+        );
+        params = new JobParametersBuilder()
+            .addString(jobLauncherTestUtils.getJob().getName(), UUID.randomUUID().toString())
+            .toJobParameters();
+        jobLauncherTestUtils.launchJob(params);
         Pair<String, String> pair = new Pair<>(
             "service-test.csv",
             "service-test.csv file is not exists in container"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
         var result = jdbcTemplate.queryForList(auditSchedulerQuery);
-        assertEquals(0, result.size());
+        assertEquals(1, result.size());
+        Assertions.assertEquals(1, jdbcTemplate.queryForList(lrdAuditSqlFailure).size());
+        List<Map<String, Object>> judicialUserRoleType = jdbcTemplate.queryForList(lrdSelectData);
+        assertFalse(judicialUserRoleType.isEmpty());
+        assertEquals(1, result.size());
+    }
+
+    private void deleteAuditAndExceptionDataOfDay1() {
+        jdbcTemplate.execute(truncateAudit);
+        jdbcTemplate.execute(truncateException);
+        SpringRestarter.getInstance().restart();
+    }
+
+    private void uploadFiles(String time) throws Exception {
+        camelContext.getGlobalOptions().put(SCHEDULER_START_TIME, time);
+        lrdBlobSupport.uploadFile(
+            "service-test.csv",
+            new FileInputStream(getFile(
+                "classpath:sourceFiles/service-test.csv"))
+        );
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdFileStatusCheckTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/LrdFileStatusCheckTest.java
@@ -131,7 +131,7 @@ public class LrdFileStatusCheckTest extends LrdIntegrationBaseTest {
         jobLauncherTestUtils.launchJob(params);
         Pair<String, String> pair = new Pair<>(
             UPLOAD_FILE_NAME,
-            "service-test.csv file is not exists in container"
+            "service-test.csv file does not exist in azure storage account"
         );
         validateLrdServiceFileException(jdbcTemplate, exceptionQuery, pair);
         var result = jdbcTemplate.queryForList(auditSchedulerQuery);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/testsupport/LrdIntegrationBaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/testsupport/LrdIntegrationBaseTest.java
@@ -73,6 +73,8 @@ public abstract class LrdIntegrationBaseTest {
     @Autowired
     protected DataIngestionLibraryRunner dataIngestionLibraryRunner;
 
+    public static final String UPLOAD_FILE_NAME = "service-test.csv";
+
     @BeforeClass
     public static void beforeAll() throws Exception {
         if ("preview".equalsIgnoreCase(System.getenv("execution_environment"))) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/testsupport/LrdIntegrationBaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/cameltest/testsupport/LrdIntegrationBaseTest.java
@@ -124,11 +124,13 @@ public abstract class LrdIntegrationBaseTest {
                                                    String exceptionQuery,
                                                    Pair<String, String> pair) {
         var result = jdbcTemplate.queryForList(exceptionQuery);
+        var lastIndex = (result.size() > 1) ? 2 : 1;
         assertThat(
-            (String) result.get(result.size() - 1).get("error_description"),
+            (String) result.get(result.size() - lastIndex).get("error_description"),
             containsString(pair.getValue1())
         );
     }
+
 
     protected Timestamp getTime(String sql, String serviceCode, String caseType) {
         return jdbcTemplate.queryForObject(sql, new Object[]{serviceCode, caseType}, Timestamp.class);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/config/LrdCamelConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/config/LrdCamelConfig.java
@@ -5,7 +5,6 @@ import org.apache.camel.component.bean.validator.HibernateValidationProviderReso
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -115,7 +114,6 @@ public class LrdCamelConfig {
         return dataSourceBuilder.build();
     }
 
-    @NotNull
     private DataSourceBuilder getDataSourceBuilder() {
         DataSourceBuilder dataSourceBuilder = DataSourceBuilder.create();
         dataSourceBuilder.driverClassName("org.postgresql.Driver");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/config/LrdCamelConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/locationrefdata/config/LrdCamelConfig.java
@@ -5,7 +5,7 @@ import org.apache.camel.component.bean.validator.HibernateValidationProviderReso
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -43,9 +43,6 @@ import static org.mockito.Mockito.mock;
 
 @Configuration
 public class LrdCamelConfig {
-
-    @Autowired
-    ApplicationContext applicationContext;
 
     @Bean
     LrdBlobSupport integrationTestSupport() {
@@ -114,21 +111,23 @@ public class LrdCamelConfig {
 
     @Bean
     public DataSource dataSource() {
+        DataSourceBuilder dataSourceBuilder = getDataSourceBuilder();
+        return dataSourceBuilder.build();
+    }
+
+    @NotNull
+    private DataSourceBuilder getDataSourceBuilder() {
         DataSourceBuilder dataSourceBuilder = DataSourceBuilder.create();
         dataSourceBuilder.driverClassName("org.postgresql.Driver");
         dataSourceBuilder.url(testPostgres.getJdbcUrl());
         dataSourceBuilder.username(testPostgres.getUsername());
         dataSourceBuilder.password(testPostgres.getPassword());
-        return dataSourceBuilder.build();
+        return dataSourceBuilder;
     }
 
     @Bean("springJdbcDataSource")
     public DataSource springJdbcDataSource() {
-        DataSourceBuilder dataSourceBuilder = DataSourceBuilder.create();
-        dataSourceBuilder.driverClassName("org.postgresql.Driver");
-        dataSourceBuilder.url(testPostgres.getJdbcUrl());
-        dataSourceBuilder.username(testPostgres.getUsername());
-        dataSourceBuilder.password(testPostgres.getPassword());
+        DataSourceBuilder dataSourceBuilder = getDataSourceBuilder();
         return dataSourceBuilder.build();
     }
 
@@ -156,11 +155,19 @@ public class LrdCamelConfig {
         return platformTransactionManager;
     }
 
-    @Bean
+    @Bean(name = "PROPAGATION_REQUIRED")
     public SpringTransactionPolicy getSpringTransaction() {
         SpringTransactionPolicy springTransactionPolicy = new SpringTransactionPolicy();
         springTransactionPolicy.setTransactionManager(txManager());
         springTransactionPolicy.setPropagationBehaviorName("PROPAGATION_REQUIRED");
+        return springTransactionPolicy;
+    }
+
+    @Bean(name = "PROPAGATION_REQUIRES_NEW")
+    public SpringTransactionPolicy propagationRequiresNew() {
+        SpringTransactionPolicy springTransactionPolicy = new SpringTransactionPolicy();
+        springTransactionPolicy.setTransactionManager(txManager());
+        springTransactionPolicy.setPropagationBehaviorName("PROPAGATION_REQUIRES_NEW");
         return springTransactionPolicy;
     }
 
@@ -191,9 +198,8 @@ public class LrdCamelConfig {
     }
 
     @Bean
-    public CamelContext camelContext() {
-        CamelContext camelContext = new SpringCamelContext(applicationContext);
-        return camelContext;
+    public CamelContext camelContext(ApplicationContext applicationContext) {
+        return new SpringCamelContext(applicationContext);
     }
     // camel related configuration ends
 

--- a/src/functionalTest/resources/application-integration.yml
+++ b/src/functionalTest/resources/application-integration.yml
@@ -67,7 +67,11 @@ exception-select-query: select * from  dataload_exception_records
 
 select-dataload-scheduler: select *  from dataload_schedular_audit
 
+select-dataload-scheduler-failure: select *  from dataload_schedular_audit where status='Failure'
+
 truncate-audit: truncate dataload_schedular_audit
+
+truncate-exception: truncate dataload_exception_records
 
 get-ccd-case-time: select created_date from SERVICE_TO_CCD_CASE_TYPE_ASSOC where service_code = ? and ccd_case_type = ?
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-2551


### Change description ###
fix: Stale files with truncate sql not roll-backing to existing data(RDCC-2251)


**Does this PR introduce a breaking change?** (check one with "x")
No
