### PR TITLE
fix: Fixed CVE CVE-2021-21295 by upgrading netty version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,34 @@ dependencies {
   compile group: 'org.apache.camel.springboot', name: 'camel-spring-boot-dependencies', version: versions.camel
 
   compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+  // Fix for CVE-2021-21295
+  implementation('io.netty:netty-buffer:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-codec:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-codec-http:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-common:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-handler:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-resolver:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-transport:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-codec-socks:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
+  implementation('io.netty:netty-handler-proxy:4.1.60.Final') {
+    because 'In Netty before version 4.1.60.Final there is a vulnerability that enables request smuggling.'
+  }
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDCC-2661


### Change description ###

Fixed CVE CVE-2021-21295 by upgrading netty version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
