### PR TITLE
fix: Upgraded apache commons io version to latest to fix CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,6 +238,8 @@ dependencies {
   compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
 
   implementation 'com.github.hmcts:data-ingestion-lib:0.4.4.0'
+  //Fix for CVE-2021-29425
+  implementation 'commons-io:commons-io:2.8.0'
   compile group: 'org.apache.camel', name: 'camel-bom', version: versions.camel, ext: 'pom'
   compile group: 'org.apache.camel.springboot', name: 'camel-spring-boot-dependencies', version: versions.camel
 


### PR DESCRIPTION
JIRA link
https://tools.hmcts.net/jira/browse/RDCC-2743

Change description
Upgraded apache commons io version to latest to fix CVE-2021-29425


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
