### PR TITLE
fix: RDCC_3512 Upgraded netty and icu version to fix CVEs CVE-2020-21913, CVE-2021-37136, CVE-2021-37137

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,7 +348,12 @@ wrapper {
 configurations.all {
   resolutionStrategy.eachDependency { details ->
     if (details.requested.group == 'io.netty') {
-      details.useVersion "4.1.63.Final"
+      details.useVersion "4.1.69.Final"
+    }
+
+    // Fix for CVE-2020-21913 & needs to be removed when camel-azure-starter is upgraded to latest version in data-ingestion-library
+    if (details.requested.group == 'com.ibm.icu') {
+      details.useVersion "66.1"
     }
   }
 }


### PR DESCRIPTION

### JIRA link ###
https://tools.hmcts.net/jira/browse/RDCC-3512


### Change description ###
Upgraded netty and icu version to fix CVEs CVE-2020-21913, CVE-2021-37136, CVE-2021-37137


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```