### PR TITLE
fix: CVE-2021-45105 by upgrading log4j to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ def versions = [
   camel               : '3.8.0',
   gradlePitest        : '1.5.1',
   pitest              : '1.7.0',
-  log4j               : '2.16.0'
+  log4j               : '2.17.0'
 ]
 
 ext.libraries = [


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-3820

### Change description ###

upgrading log4j to 2.17.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```