### PR TITLE
RDCC-5496: excluding `jettison` to fix `CVE-2022-40149` & `CVE-2022-40150`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -402,6 +402,7 @@ configurations.all {
       details.useVersion "66.1"
     }
   }
+      exclude group: 'org.codehaus.jettison', module: 'jettison'
 }
 
 test {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5496

### Change description ###

excluding `jettison` to fix `CVE-2022-40149` & `CVE-2022-40150`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
