### PR TITLE
Addresses CVE-2023-20863

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ def versions = [
   pitest              : '1.7.4',
   jackson             : '2.14.2',
   log4j               : '2.17.1',
-  springVersion       : '5.3.26',
+  springVersion       : '5.3.27',
   logback             : '1.2.10'
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-264

### Change description ###

Addresses nightly build failure due to CVE-2023-20863

Mitigated in spring 5.3.27
https://spring.io/security/cve-2023-20863



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
