### PR TITLE
DTSRD-1456

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -403,6 +403,20 @@ dependencyManagement {
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
     }
+
+    //        Resolves CVE-2023-4586
+    dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+      entry 'netty-buffer'
+      entry 'netty-codec'
+      entry 'netty-codec-http'
+      entry 'netty-codec-socks'
+      entry 'netty-common'
+      entry 'netty-handler'
+      entry 'netty-handler-proxy'
+      entry 'netty-resolver'
+      entry 'netty-transport'
+      entry 'netty-transport-native-unix-common'
+    }
   }
 }
 
@@ -425,10 +439,6 @@ wrapper {
 // Fix for CVE-2021-21295 & need to be removed with new Azure blob version
 configurations.all {
   resolutionStrategy.eachDependency { details ->
-    if (details.requested.group == 'io.netty') {
-      details.useVersion "4.1.94.Final"
-    }
-
     // Fix for CVE-2020-21913 & needs to be removed when camel-azure-starter is upgraded to latest version in data-ingestion-library
     if (details.requested.group == 'com.ibm.icu') {
       details.useVersion "66.1"

--- a/charts/rd-location-ref-data-load/Chart.yaml
+++ b/charts/rd-location-ref-data-load/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
   - name: Reference Data Team
 dependencies:
   - name: job
-    version: 1.0.0
+    version: 1.1.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: blobstorage
     version: 1.0.1

--- a/charts/rd-location-ref-data-load/Chart.yaml
+++ b/charts/rd-location-ref-data-load/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for RD Location Ref Data Load App
 name: rd-location-ref-data-load
 home: https://github.com/hmcts/rd-location-ref-data-load
-version: 0.0.24
+version: 0.0.25
 maintainers:
   - name: Reference Data Team
 dependencies:


### PR DESCRIPTION
- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of job helm chart below 1.1.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-job/releases This configuration will stop working by 23/10/2023

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-1456

### Change description ###

- Updating Netty versions for CVE-2023-4586.
- Updating helm version; Version of job helm chart below 1.1.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-job/releases This configuration will stop working by 23/10/2023

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
