### PR TITLE
Addresses CVE-2023-42794, CVE-2023-42795 and CVE-2023-45648

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,7 +398,7 @@ dependencyManagement {
   dependencies {
     // CVE-2021-42340
     // CVE-2023-28709
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.80') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.81') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'


### PR DESCRIPTION
### Change description ###

Addresses nightly build failure due to [CVE-2023-42794](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42794), [CVE-2023-42795](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42795) and
[CVE-2023-45648](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-45648)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
